### PR TITLE
Fix code scanning alert no. 55: Server-side request forgery

### DIFF
--- a/src/services/cms/bunny/BunnyClient.ts
+++ b/src/services/cms/bunny/BunnyClient.ts
@@ -223,8 +223,8 @@ export class BunnyClient {
   deleteCDNImage = async (filePath: string, linkedHostname: string, zoneName: string): Promise<APIResponse<string>> => {
     const parseUrl = filePath && url.parse(filePath);
     const existingPath = parseUrl && parseUrl.pathname;
-    if (parseUrl && parseUrl.host === linkedHostname) {
-      const deleteUrl = `https://storage.bunnycdn.com/${zoneName}/${existingPath}`;
+    if (parseUrl && parseUrl.host === linkedHostname && this.isValidPath(existingPath)) {
+      const deleteUrl = `https://storage.bunnycdn.com/${zoneName}/${encodeURIComponent(existingPath)}`;
       const response = await fetch(deleteUrl, this.getDeleteOption());
       if (response.ok) {
         return new APIResponse(true, response.status, response.statusText);
@@ -534,4 +534,8 @@ export class BunnyClient {
       "Successfully deleted the watermark"
     );
   };
+  isValidPath(path: string): boolean {
+    const allowedPathPattern = /^\/[a-zA-Z0-9_\-\/]+$/;
+    return allowedPathPattern.test(path);
+  }
 }


### PR DESCRIPTION
Fixes [https://github.com/torqbit/torqbit/security/code-scanning/55](https://github.com/torqbit/torqbit/security/code-scanning/55)

To fix the SSRF vulnerability, we need to ensure that the `filePath` parameter is properly validated and sanitized before being used to construct the `deleteUrl`. Specifically, we should:

1. Validate the `filePath` to ensure it does not contain any malicious input.
2. Use a whitelist of allowed paths or patterns to restrict the possible values of `filePath`.
3. Ensure that the `existingPath` is properly encoded to prevent any path traversal or injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
