### PR TITLE
Fix code scanning alert no. 50: Server-side request forgery

### DIFF
--- a/src/pages/api/v1/upload/file/delete.ts
+++ b/src/pages/api/v1/upload/file/delete.ts
@@ -9,6 +9,13 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const body = await req.body;
     const { name, dir } = body;
 
+    // Validate name and dir values
+    const isValidName = /^[a-zA-Z0-9-_]+$/.test(name);
+    const isValidDir = /^[a-zA-Z0-9-_]+$/.test(dir);
+    if (!isValidName || !isValidDir) {
+      return res.status(400).json({ success: false, message: "Invalid name or dir value" });
+    }
+
     const service_provider = await prisma.serviceProvider.findFirst({
       where: {
         provider_name: "bunny img",


### PR DESCRIPTION
Fixes [https://github.com/torqbit/torqbit/security/code-scanning/50](https://github.com/torqbit/torqbit/security/code-scanning/50)

To fix the problem, we need to ensure that the user-provided values (`name` and `dir`) are validated and sanitized before being used to construct the URL for the `fetch` request. This can be achieved by implementing a whitelist of allowed values or by performing strict validation to ensure that the values do not contain any malicious content.

The best way to fix the problem without changing existing functionality is to:
1. Validate the `name` and `dir` values to ensure they only contain allowed characters (e.g., alphanumeric characters, hyphens, underscores).
2. Reject any requests with invalid `name` or `dir` values.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
