### PR TITLE
Fix code scanning alert no. 49: Uncontrolled data used in path expression

### DIFF
--- a/src/pages/api/v1/course/update.ts
+++ b/src/pages/api/v1/course/update.ts
@@ -5,6 +5,7 @@ import { withMethods } from "@/lib/api-middlewares/with-method";
 import { withUserAuthorized } from "@/lib/api-middlewares/with-authorized";
 import { createSlug, getFileExtension } from "@/lib/utils";
 import fs from "fs";
+import path from "path";
 import { APIResponse } from "@/types/apis";
 import { readFieldWithSingleFile } from "@/lib/upload/utils";
 import { ContentManagementService } from "@/services/cms/ContentManagementService";
@@ -59,8 +60,12 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
           }
 
           const extension = getFileExtension(files.file[0].originalFilename);
-          const sourcePath = files.file[0].filepath;
-          const fileBuffer = await fs.promises.readFile(`${sourcePath}`);
+          const sourcePath = path.resolve(files.file[0].filepath);
+          const safeDir = path.resolve("/var/www/uploads"); // Replace with your safe directory
+          if (!sourcePath.startsWith(safeDir)) {
+            throw new Error("Invalid file path");
+          }
+          const fileBuffer = await fs.promises.readFile(sourcePath);
           //now upload the image
           const newThumbnailResponse = await cms.uploadVideoThumbnail(
             cmsConfig,


### PR DESCRIPTION
Fixes [https://github.com/torqbit/torqbit/security/code-scanning/49](https://github.com/torqbit/torqbit/security/code-scanning/49)

To fix the problem, we need to ensure that the `sourcePath` is validated before it is used to read the file. We can achieve this by normalizing the path and ensuring it is within a designated safe directory. This will prevent path traversal attacks.

1. Normalize the `sourcePath` using `path.resolve`.
2. Check that the normalized path starts with the designated safe directory.
3. If the path is not valid, handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
