### PR TITLE
Potential fix for code scanning alert no. 84: Client-side cross-site scripting

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "sodium-native": "^4.3.1",
     "typescript": "5.0.3",
     "yaml": "^2.6.1",
-    "zod": "^3.21.4"
+    "zod": "^3.21.4",
+    "dompurify": "^3.2.3"
   },
   "resolutions": {
     "string-width": "4.2.3",

--- a/src/templates/standard/components/NavBar/SideNavBar.tsx
+++ b/src/templates/standard/components/NavBar/SideNavBar.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useState } from "react";
 import Link from "next/link";
+import DOMPurify from "dompurify";
 
 import { Badge, Drawer, Flex } from "antd";
 import styles from "./NavBar.module.scss";
@@ -139,7 +140,7 @@ const MobileNav: FC<INavBarProps> = ({ items, showThemeSwitch, activeTheme, bran
                           <Link
                             key={i}
                             style={{ color: "var(--font-secondary)" }}
-                            href={item.link}
+                            href={DOMPurify.sanitize(item.link)}
                             aria-label={`link to ${item.title}`}
                           >
                             {item.title}


### PR DESCRIPTION
Potential fix for [https://github.com/torqbit/torqbit/security/code-scanning/84](https://github.com/torqbit/torqbit/security/code-scanning/84)

To fix the problem, we need to ensure that the `item.link` value is properly sanitized before being used in the `href` attribute. This can be achieved by using a library like `DOMPurify` to sanitize the URL. We will import `DOMPurify` and use it to sanitize the `item.link` value before rendering it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
